### PR TITLE
Change timestamp format for new change files

### DIFF
--- a/lib/codelog/command/new.rb
+++ b/lib/codelog/command/new.rb
@@ -13,7 +13,7 @@ module Codelog
         chdir Dir.pwd do
           # This script create a change file for the changelog documentation.
 
-          full_file_name = "changelogs/unreleased/#{Time.now.to_i}_change.yml"
+          full_file_name = "changelogs/unreleased/#{Time.now.strftime('%Y%m%d%H%M%S%L')}_change.yml"
 
           puts "== Creating #{full_file_name} change file based on example =="
           system! "cp changelogs/template.yml #{full_file_name}"

--- a/spec/codelog/command/new_spec.rb
+++ b/spec/codelog/command/new_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Codelog::Command::New do
   describe '#run' do
     before :each do
-      allow(Time).to receive_message_chain(:now, :to_i) { '1234' }
+      allow(Time).to receive_message_chain(:now, :strftime) { '20180119134323984' }
       allow(subject).to receive(:puts)
       allow(subject).to receive(:system) { true }
       subject.run
@@ -11,12 +11,12 @@ describe Codelog::Command::New do
 
     it 'prints a message to notify the user about the file creation' do
       expect(subject).to have_received(:puts)
-        .with('== Creating changelogs/unreleased/1234_change.yml change file based on example ==')
+        .with('== Creating changelogs/unreleased/20180119134323984_change.yml change file based on example ==')
     end
 
     it 'creates a file for the unreleased partial changes' do
       expect(subject).to have_received(:system)
-        .with('cp changelogs/template.yml changelogs/unreleased/1234_change.yml')
+        .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_change.yml')
     end
   end
 


### PR DESCRIPTION
This changes the current format for 'codelog new'-generated
change files from Unix Epoch format to a human-readable format.

former: 1516389093_change.yml
new: 20180119171207818_change.yml

The rationale behid it is that when searching for a partial
changelog file between releases is much easier if we can search
by filename. For example: I know a change was made yesterday during
the morning, so I can 'easily' know which file corresponds to it,
even if we have a lot of yml files under 'unreleased' directory.

Signed-off-by: Luiz Cavalcanti <luiz.cavalcanti@codus.com.br>