### PR TITLE
Nested Markdown by yml file

### DIFF
--- a/changelogs/unreleased/20180208185522173_change.yml
+++ b/changelogs/unreleased/20180208185522173_change.yml
@@ -1,0 +1,3 @@
+"Fixed":
+  - Nested YML entries were print as hashes. Now codelog generates a nested Markdown
+

--- a/lib/codelog/command/step/version.rb
+++ b/lib/codelog/command/step/version.rb
@@ -52,9 +52,7 @@ module Codelog
               add_entry(line, values, level + 1)
             end
           elsif changes.is_a?(Array)
-            changes.each do |change|
-              add_entry(line, change, level)
-            end
+            changes.each { |change| add_entry(line, change, level) }
           else
             line.puts "#{"\t" * level}- #{changes}"
           end

--- a/lib/codelog/command/step/version.rb
+++ b/lib/codelog/command/step/version.rb
@@ -45,12 +45,27 @@ module Codelog
           end
         end
 
+        def add_entry(line, changes, level = 0)
+          if changes.is_a?(Hash)
+            changes.each do |key, values|
+              line.puts "#{"\t" * level}- #{key}"
+              add_entry(line, values, level + 1)
+            end
+          elsif changes.is_a?(Array)
+            changes.each do |change|
+              add_entry(line, change, level)
+            end
+          else
+            line.puts "#{"\t" * level}- #{changes}"
+          end
+        end
+
         def create_version_changelog_from(changes_hash)
           File.open("#{RELEASES_PATH}/#{@version}.md", 'a') do |line|
             line.puts "## #{Codelog::Config.version_tag(@version, @release_date)}"
             changes_hash.each do |category, changes|
               line.puts "### #{category}"
-              changes.each { |change| line.puts "- #{change}" }
+              add_entry(line, changes)
               line.puts "\n"
             end
             line.puts "---\n"

--- a/lib/codelog/version.rb
+++ b/lib/codelog/version.rb
@@ -1,3 +1,3 @@
 module Codelog
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
When yml has identation by:

```
- topic A:
   - topic A1
   - topic A2
```

is translated to Markdown:

```
- {"topic A" => ["topic A1", "topic A2"]}
```

This PR changes to:

```
- topic A
   - topic A1
   - topic A2
```