### PR TITLE
Ability to open changefile in default editor after creating it

### DIFF
--- a/changelogs/unreleased/20180215141923449_change.yml
+++ b/changelogs/unreleased/20180215141923449_change.yml
@@ -1,0 +1,2 @@
+"Added":
+  - Ability to edit the created changefile by running `codelog new <-e|--edit>`

--- a/lib/codelog/cli.rb
+++ b/lib/codelog/cli.rb
@@ -11,7 +11,7 @@ module Codelog
 
     desc 'new', 'Generate a file from the template for the unreleased changes'
     def new
-      Codelog::Command::New.run
+      Codelog::Command::New.run options
     end
 
     desc 'release [VERSION] <RELEASE_DATE>', 'Generate new release updating changelog'

--- a/lib/codelog/cli.rb
+++ b/lib/codelog/cli.rb
@@ -10,6 +10,8 @@ module Codelog
     end
 
     desc 'new', 'Generate a file from the template for the unreleased changes'
+    method_option :edit, desc: 'Opens the default system editor after creating a changefile',
+                         aliases: '-e', type: :boolean
     def new
       Codelog::Command::New.run options
     end

--- a/lib/codelog/command/new.rb
+++ b/lib/codelog/command/new.rb
@@ -5,11 +5,11 @@ module Codelog
     class New
       include FileUtils
 
-      def self.run
-        Codelog::Command::New.new.run
+      def self.run(options)
+        Codelog::Command::New.new.run options
       end
 
-      def run
+      def run(options)
         chdir Dir.pwd do
           # This script create a change file for the changelog documentation.
 

--- a/lib/codelog/command/new.rb
+++ b/lib/codelog/command/new.rb
@@ -17,11 +17,18 @@ module Codelog
 
           puts "== Creating #{full_file_name} change file based on example =="
           system! "cp changelogs/template.yml #{full_file_name}"
-          system! "${VISUAL:-${EDITOR:-nano}} #{full_file_name}" if options[:edit]
+          system! "#{default_editor} #{full_file_name}" if options[:edit]
         end
       end
 
       private
+
+      def default_editor
+        # Looks for the default editor in VISUAL and EDITOR system variables
+        # if no variable is set it defaults to nano
+
+        '${VISUAL:-${EDITOR:-nano}}'
+      end
 
       def system!(*args)
         system(*args) || abort("\n== Command #{args} failed ==")

--- a/lib/codelog/command/new.rb
+++ b/lib/codelog/command/new.rb
@@ -17,6 +17,7 @@ module Codelog
 
           puts "== Creating #{full_file_name} change file based on example =="
           system! "cp changelogs/template.yml #{full_file_name}"
+          system! "${VISUAL:-${EDITOR:-nano}} #{full_file_name}" if options[:edit]
         end
       end
 

--- a/spec/codelog/command/new_spec.rb
+++ b/spec/codelog/command/new_spec.rb
@@ -6,24 +6,49 @@ describe Codelog::Command::New do
       allow(Time).to receive_message_chain(:now, :strftime) { '20180119134323984' }
       allow(subject).to receive(:puts)
       allow(subject).to receive(:system) { true }
-      subject.run
+      subject.run(options)
     end
 
-    it 'prints a message to notify the user about the file creation' do
-      expect(subject).to have_received(:puts)
+    context 'with no additional options' do
+      let(:options) { Hash.new }
+
+      it 'prints a message to notify the user about the file creation' do
+        expect(subject).to have_received(:puts)
         .with('== Creating changelogs/unreleased/20180119134323984_change.yml change file based on example ==')
+      end
+
+      it 'creates a file for the unreleased partial changes' do
+        expect(subject).to have_received(:system)
+        .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_change.yml')
+      end
     end
 
-    it 'creates a file for the unreleased partial changes' do
-      expect(subject).to have_received(:system)
+    context "with 'edit' option" do
+      let(:options) {{ edit: true }}
+
+      it 'prints a message to notify the user about the file creation' do
+        expect(subject).to have_received(:puts)
+        .with('== Creating changelogs/unreleased/20180119134323984_change.yml change file based on example ==')
+      end
+
+      it 'creates a file for the unreleased partial changes' do
+        expect(subject).to have_received(:system)
         .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_change.yml')
+      end
+
+      it 'opens the default text editor with the created file' do
+        expect(subject).to have_received(:system)
+        .with('${VISUAL:-${EDITOR:-nano}} changelogs/unreleased/20180119134323984_change.yml')
+      end
     end
   end
 
   describe '.run' do
     it 'creates an instance of the class to run the command' do
-      expect_any_instance_of(described_class).to receive(:run)
-      described_class.run
+      options = {}
+
+      expect_any_instance_of(described_class).to receive(:run).with(options)
+      described_class.run(options)
     end
   end
 end


### PR DESCRIPTION
## Objective
When creating a changefile you can now pass `--edit` or `-e` parameter to instantly open the default text editor and add your changes

## Related Issues
This partially solves #28, although a fully featured interactive mode would still be desirable

## Notes
The default editor is determined by shell environment variables `$VISUAL` or `$EDITOR`, or else falls back to the `nano` editor

## Preview
![peek 2018-02-15 15-09](https://user-images.githubusercontent.com/8629086/36270249-5b79eb5e-1262-11e8-92a4-dbb48ea48d87.gif)
