### PR TITLE
Friendly error message when invalid character in any unreleased file

### DIFF
--- a/changelogs/unreleased/20180222130339054_change.yml
+++ b/changelogs/unreleased/20180222130339054_change.yml
@@ -1,0 +1,2 @@
+"Fixed":
+  - When an unreleased file is not parseable to yml, the user will get a friendly message, saying both file and line that are wrong.

--- a/lib/codelog/command/step/version.rb
+++ b/lib/codelog/command/step/version.rb
@@ -43,6 +43,8 @@ module Codelog
               changes | changes_to_be_added
             end
           end
+        rescue Psych::SyntaxError => error
+          abort(Codelog::Message::Error.could_not_parse_yaml(error))
         end
 
         def create_version_changelog_from(changes_hash)

--- a/lib/codelog/message.rb
+++ b/lib/codelog/message.rb
@@ -34,7 +34,7 @@ module Codelog
         end
 
         def could_not_parse_yaml(error)
-          "#{prefix}: #{error.problem.capitalize} in the line #{error.line} in #{error.file}"
+          "#{prefix}: #{error.problem.capitalize} in #{error.file}:#{error.line}"
         end
       end
     end

--- a/lib/codelog/message.rb
+++ b/lib/codelog/message.rb
@@ -32,6 +32,10 @@ module Codelog
           "Run the following command to create the missing file:\n\n" \
           'codelog setup'
         end
+
+        def could_not_parse_yaml(error)
+          "#{prefix}: #{error.problem.capitalize} in the line #{error.line} in #{error.file}"
+        end
       end
     end
 

--- a/lib/codelog/version.rb
+++ b/lib/codelog/version.rb
@@ -1,3 +1,3 @@
 module Codelog
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/spec/codelog/command/step/version_spec.rb
+++ b/spec/codelog/command/step/version_spec.rb
@@ -123,7 +123,7 @@ describe Codelog::Command::Step::Version do
 
 
   describe '#changes_hash' do
-    context "when a not parseable yml file is given" do
+    context "when a non parseable yml file is given" do
       subject {described_class.new('1.2.3', '2012-12-12')}
 
       it 'aborts with an appropriate error message' do

--- a/spec/codelog/command/step/version_spec.rb
+++ b/spec/codelog/command/step/version_spec.rb
@@ -126,9 +126,11 @@ describe Codelog::Command::Step::Version do
     context "when a non parseable yml file is given" do
       subject {described_class.new('1.2.3', '2012-12-12')}
 
-      it 'aborts with an appropriate error message' do
-        allow(Dir).to receive(:"[]") { ["spec/fixtures/files/not_parseable.yml"] }
-        expect { subject.run }.to raise_error SystemExit
+      before(:each) { allow(Dir).to receive(:"[]") { ["spec/fixtures/files/not_parseable.yml"] } }
+
+      it 'aborts with the appropriate message' do
+        expect { subject.run }.to raise_error(SystemExit).
+                with_message("ERROR: Found character that cannot start any token in spec/fixtures/files/not_parseable.yml:3")
       end
     end
   end

--- a/spec/codelog/command/step/version_spec.rb
+++ b/spec/codelog/command/step/version_spec.rb
@@ -123,10 +123,10 @@ describe Codelog::Command::Step::Version do
 
 
   describe '#changes_hash' do
-    context "with a not parseable yml file raises an error" do
+    context "when a not parseable yml file is given" do
       subject {described_class.new('1.2.3', '2012-12-12')}
 
-      it 'aborts with appropriate error message of parse' do
+      it 'aborts with an appropriate error message' do
         double_error = double("Psych::SyntaxError", problem: "found character that cannot start any token", line: "2", file: "spec/fixtures/files/not_parseable.yml")
         allow(Dir).to receive(:"[]") { ["spec/fixtures/files/not_parseable.yml"] }
         lambda { subject.run }.should raise_error SystemExit

--- a/spec/codelog/command/step/version_spec.rb
+++ b/spec/codelog/command/step/version_spec.rb
@@ -127,9 +127,8 @@ describe Codelog::Command::Step::Version do
       subject {described_class.new('1.2.3', '2012-12-12')}
 
       it 'aborts with an appropriate error message' do
-        double_error = double("Psych::SyntaxError", problem: "found character that cannot start any token", line: "2", file: "spec/fixtures/files/not_parseable.yml")
         allow(Dir).to receive(:"[]") { ["spec/fixtures/files/not_parseable.yml"] }
-        lambda { subject.run }.should raise_error SystemExit
+        expect { subject.run }.to raise_error SystemExit
       end
     end
   end

--- a/spec/codelog/command/step/version_spec.rb
+++ b/spec/codelog/command/step/version_spec.rb
@@ -126,9 +126,8 @@ describe Codelog::Command::Step::Version do
     context "when a non parseable yml file is given" do
       subject {described_class.new('1.2.3', '2012-12-12')}
 
-      before(:each) { allow(Dir).to receive(:"[]") { ["spec/fixtures/files/not_parseable.yml"] } }
-
       it 'aborts with the appropriate message' do
+        allow(Dir).to receive(:"[]") { ["spec/fixtures/files/not_parseable.yml"] }
         expect { subject.run }.to raise_error(SystemExit).
                 with_message("ERROR: Found character that cannot start any token in spec/fixtures/files/not_parseable.yml:3")
       end

--- a/spec/codelog/command/step/version_spec.rb
+++ b/spec/codelog/command/step/version_spec.rb
@@ -68,7 +68,7 @@ describe Codelog::Command::Step::Version do
           allow(subject).to receive(:unreleased_changes?).and_return(true)
           allow(subject).to receive(:create_version_changelog_from)
           allow(Codelog::Config).to receive(:version_tag)
-            .with(nil, '2012-12-12')
+            .with(nil, '2012-12-12')  
         end
 
         subject { described_class.new(nil, '2012-12-12') }
@@ -92,7 +92,7 @@ describe Codelog::Command::Step::Version do
           expect(subject).to receive(:abort).with Codelog::Message::Error.already_existing_version('1.2.3')
           subject.run
         end
-      end
+      end 
 
       describe 'with no changes to be released' do
         before :each do
@@ -128,8 +128,9 @@ describe Codelog::Command::Step::Version do
 
       it 'aborts with the appropriate message' do
         allow(Dir).to receive(:"[]") { ["spec/fixtures/files/not_parseable.yml"] }
-        expect { subject.run }.to raise_error(SystemExit).
-                with_message("ERROR: Found character that cannot start any token in spec/fixtures/files/not_parseable.yml:3")
+        # Regex will match the error message raised by SystemExit both Ruby and JRuby
+        expect { subject.run }.to raise_error(SystemExit)
+          .with_message(/ERROR: Found character(.)*that cannot start any token(.)*in spec\/fixtures\/files\/not_parseable.yml:3/)
       end
     end
   end

--- a/spec/codelog/command/step/version_spec.rb
+++ b/spec/codelog/command/step/version_spec.rb
@@ -120,4 +120,17 @@ describe Codelog::Command::Step::Version do
       described_class.run '1.2.3', '2012-12-12'
     end
   end
+
+
+  describe '#changes_hash' do
+    context "with a not parseable yml file raises an error" do
+      subject {described_class.new('1.2.3', '2012-12-12')}
+
+      it 'aborts with appropriate error message of parse' do
+        double_error = double("Psych::SyntaxError", problem: "found character that cannot start any token", line: "2", file: "spec/fixtures/files/not_parseable.yml")
+        allow(Dir).to receive(:"[]") { ["spec/fixtures/files/not_parseable.yml"] }
+        lambda { subject.run }.should raise_error SystemExit
+      end
+    end
+  end
 end

--- a/spec/fixtures/files/not_parseable.yml
+++ b/spec/fixtures/files/not_parseable.yml
@@ -1,0 +1,2 @@
+"Fixed":
+  - `Non-default input date format`

--- a/spec/fixtures/files/not_parseable.yml
+++ b/spec/fixtures/files/not_parseable.yml
@@ -1,2 +1,2 @@
-"Fixed":
-  - `Non-default input date format`
+"Title":
+  - `description`

--- a/spec/fixtures/files/not_parseable.yml
+++ b/spec/fixtures/files/not_parseable.yml
@@ -1,2 +1,3 @@
+# During the loading process of this YAML, the "`" character is reserved by YAML specification. Then it will raise an error.
 "Title":
   - `description`


### PR DESCRIPTION
## Objective
<!--- Why is this change required? What problem does it solve? -->
<!--- Provide a general summary of your changes -->
<!--- If it fixes an open issue, please link to the issue here. -->
Based on: https://github.com/codus/codelog/issues/25

Before this pull request a user of codelog would insert some invalid character in the unreleased yml files and when the user tries to generate a new release, an error that is not user friendly is displayed. Then,  the origin of the problem is unknown.
To provide a more user friendly message i opened this pull request.
Now when the same thing happens, a message is shown to the user, with file and line, where the problem happened, helping with the necessary information for fixes.

## How to test
<!-- If testing the changes require a special setup or environment, please describe it in detail here -->
<!--- Provide an unambiguous set of steps to correctly setup and test the changes: -->
1. A fixture was created to provide a yml file with invalid character, and a test to check if an error with a friendly message is raised when any unreleased file has invalid characters.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **[CONTRIBUTING]** document.
- [X] I have created a _Codelog changefile_ with the changes made to the branch.
- [X] I have created a test proving that my feature/fix does what it intends to do.

[CONTRIBUTING]: https://github.com/codus/codelog/blob/master/CONTRIBUTING.md
