### PR TITLE
Customize the change file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,21 +68,27 @@ The template can be as the following example:
 
 ## Usage
 
+### Creating a new change file
+
 After the initial setup every time a change is made, the developer should run the following command in the project root path:
 
 ``` bash
-$ codelog new
+$ codelog new <NAME>
 ```
 
-This will generate a change file on `changelogs/unreleased/` from the `template.yml` named with a timestamp value followed by `_change.yml`.
+This will generate a change file, in `YAML` format, on `changelogs/unreleased/` from the `template.yml`, named with a timestamp value followed by the the given `NAME`, converted to snake case, or the default name(`change`).
 
 The new change file should be filled with informations about the implemented change, all unused topics should be erased and the file committed.
+
+### Releasing a version
 
 Once all changes were merged and the release is ready to be packed, all that must be done is to run the following command:
 
 ``` bash
-$ codelog release {x.y.z}
+$ codelog release [VERSION] <RELEASE_DATE>
 ```
+Where the `VERSION` is mandatory and represents the number of the next version of the system. An additional parameter `RELEASE_DATE` can be used, and if so, the release date of the version will be that value. You can configure the format of this parameter in the configuration file, under `changelogs/codelog.yml`.
+
 No conflicts to resolve. All changes documented.
 
 It will execute 3 steps:

--- a/changelogs/unreleased/20180301000403161_change_file_name.yml
+++ b/changelogs/unreleased/20180301000403161_change_file_name.yml
@@ -1,2 +1,2 @@
 "Added":
-  - "The new command receives a `NAME` parameter that will be converted to the unreleased file name"
+  - "The `new` command receives a `NAME` parameter that will be converted to the unreleased file name"

--- a/changelogs/unreleased/20180301000403161_change_file_name.yml
+++ b/changelogs/unreleased/20180301000403161_change_file_name.yml
@@ -1,0 +1,2 @@
+"Added":
+  - "The new command receives a `NAME` parameter that will be converted to the unreleased file name"

--- a/lib/codelog/cli.rb
+++ b/lib/codelog/cli.rb
@@ -9,11 +9,11 @@ module Codelog
       Codelog::Command::Setup.run
     end
 
-    desc 'new', 'Generate a file from the template for the unreleased changes'
+    desc 'new <NAME>', 'Generate a file from the template for the unreleased changes'
     method_option :edit, desc: 'Opens the default system editor after creating a changefile',
                          aliases: '-e', type: :boolean
-    def new
-      Codelog::Command::New.run options
+    def new(name = 'change')
+      Codelog::Command::New.run name, options
     end
 
     desc 'release [VERSION] <RELEASE_DATE>', 'Generate new release updating changelog'

--- a/lib/codelog/command/new.rb
+++ b/lib/codelog/command/new.rb
@@ -40,6 +40,8 @@ module Codelog
       end
 
       def change_file_name
+        # Converts the name to snake case
+
         @name.gsub(/(.)([A-Z])/, '\1_\2').downcase
       end
 

--- a/lib/codelog/command/new.rb
+++ b/lib/codelog/command/new.rb
@@ -5,19 +5,24 @@ module Codelog
     class New
       include FileUtils
 
-      def self.run(options)
-        Codelog::Command::New.new.run options
+      def initialize(name, options)
+        @name = name
+        @options = options
       end
 
-      def run(options)
+      def self.run(name, options)
+        Codelog::Command::New.new(name, options).run
+      end
+
+      def run
         chdir Dir.pwd do
           # This script create a change file for the changelog documentation.
 
-          full_file_name = "changelogs/unreleased/#{Time.now.strftime('%Y%m%d%H%M%S%L')}_change.yml"
+          full_file_name = "changelogs/unreleased/#{change_file_timestamp}_#{change_file_name}.yml"
 
           puts "== Creating #{full_file_name} change file based on example =="
           system! "cp changelogs/template.yml #{full_file_name}"
-          system! "#{default_editor} #{full_file_name}" if options[:edit]
+          system! "#{default_editor} #{full_file_name}" if @options[:edit]
         end
       end
 
@@ -28,6 +33,14 @@ module Codelog
         # if no variable is set it defaults to nano
 
         '${VISUAL:-${EDITOR:-nano}}'
+      end
+
+      def change_file_timestamp
+        Time.now.strftime('%Y%m%d%H%M%S%L')
+      end
+
+      def change_file_name
+        @name.gsub(/(.)([A-Z])/, '\1_\2').downcase
       end
 
       def system!(*args)

--- a/lib/codelog/command/new.rb
+++ b/lib/codelog/command/new.rb
@@ -11,7 +11,7 @@ module Codelog
       end
 
       def self.run(name, options)
-        Codelog::Command::New.new(name, options).run
+        new(name, options).run
       end
 
       def run

--- a/spec/codelog/cli_spec.rb
+++ b/spec/codelog/cli_spec.rb
@@ -19,8 +19,9 @@ describe Codelog::CLI do
     end
 
     it 'pass the change name to the command' do
+      default_options = {}
       subject.new('test_name')
-      expect(Codelog::Command::New).to have_received(:run).with('test_name', {})
+      expect(Codelog::Command::New).to have_received(:run).with('test_name', default_options)
     end
   end
 

--- a/spec/codelog/cli_spec.rb
+++ b/spec/codelog/cli_spec.rb
@@ -8,16 +8,30 @@ describe Codelog::CLI do
     end
   end
 
-  context 'with generic commands' do
-    GENERIC_COMMANDS = ['setup', 'new'].freeze
+  describe '#new' do
+    before :each do
+      allow(Codelog::Command::New).to receive(:run)
+    end
 
-    GENERIC_COMMANDS.each do |command|
-      it "calls the #{command} command" do
-        command_class = Module.const_get "Codelog::Command::#{command.capitalize}"
-        allow(command_class).to receive(:run)
-        subject.send(command)
-        expect(command_class).to have_received(:run)
-      end
+    it 'calls the new command' do
+      subject.new
+      expect(Codelog::Command::New).to have_received(:run)
+    end
+
+    it 'pass the change name to the command' do
+      subject.new('test_name')
+      expect(Codelog::Command::New).to have_received(:run).with('test_name', {})
+    end
+  end
+
+  describe '#setup' do
+    before :each do
+      allow(Codelog::Command::Setup).to receive(:run)
+    end
+
+    it 'calls the setup command' do
+      subject.setup
+      expect(Codelog::Command::Setup).to have_received(:run)
     end
   end
 

--- a/spec/codelog/command/new_spec.rb
+++ b/spec/codelog/command/new_spec.rb
@@ -14,22 +14,34 @@ describe Codelog::Command::New do
       subject.run
     end
 
-    it 'prints a message to notify the user about the file creation' do
-      expect(subject).to have_received(:puts)
+    context 'with no additional options' do
+      it 'prints a message to notify the user about the file creation' do
+        expect(subject).to have_received(:puts)
         .with('== Creating changelogs/unreleased/20180119134323984_change.yml change file based on example ==')
-    end
+      end
 
-    it 'creates a file for the unreleased partial changes' do
-      expect(subject).to have_received(:system)
+      it 'creates a file for the unreleased partial changes' do
+        expect(subject).to have_received(:system)
         .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_change.yml')
+      end
     end
 
     context "with 'edit' option" do
-      let(:options) { { edit: true } }
+      let(:options) {{ edit: true }}
+
+      it 'prints a message to notify the user about the file creation' do
+        expect(subject).to have_received(:puts)
+        .with('== Creating changelogs/unreleased/20180119134323984_change.yml change file based on example ==')
+      end
+
+      it 'creates a file for the unreleased partial changes' do
+        expect(subject).to have_received(:system)
+        .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_change.yml')
+      end
 
       it 'opens the default text editor with the created file' do
         expect(subject).to have_received(:system)
-          .with('${VISUAL:-${EDITOR:-nano}} changelogs/unreleased/20180119134323984_change.yml')
+        .with('${VISUAL:-${EDITOR:-nano}} changelogs/unreleased/20180119134323984_change.yml')
       end
     end
 
@@ -39,7 +51,12 @@ describe Codelog::Command::New do
       it 'converts the string to snake case notation, creating the file using it' do
         expect(subject).to have_received(:system)
           .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_test_name.yml')
-      end 
+      end
+
+      it 'prints a message of the file creation, using the custom name' do
+        expect(subject).to have_received(:puts)
+        .with('== Creating changelogs/unreleased/20180119134323984_test_name.yml change file based on example ==')
+      end
     end
   end
 

--- a/spec/codelog/command/new_spec.rb
+++ b/spec/codelog/command/new_spec.rb
@@ -2,53 +2,51 @@ require 'spec_helper'
 
 describe Codelog::Command::New do
   describe '#run' do
+    let(:name) { 'change' }
+    let(:options) { {} }
+
+    subject { described_class.new name, options }
+    
     before :each do
       allow(Time).to receive_message_chain(:now, :strftime) { '20180119134323984' }
       allow(subject).to receive(:puts)
       allow(subject).to receive(:system) { true }
-      subject.run(options)
+      subject.run
     end
 
-    context 'with no additional options' do
-      let(:options) { Hash.new }
-
-      it 'prints a message to notify the user about the file creation' do
-        expect(subject).to have_received(:puts)
+    it 'prints a message to notify the user about the file creation' do
+      expect(subject).to have_received(:puts)
         .with('== Creating changelogs/unreleased/20180119134323984_change.yml change file based on example ==')
-      end
+    end
 
-      it 'creates a file for the unreleased partial changes' do
-        expect(subject).to have_received(:system)
+    it 'creates a file for the unreleased partial changes' do
+      expect(subject).to have_received(:system)
         .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_change.yml')
-      end
     end
 
     context "with 'edit' option" do
-      let(:options) {{ edit: true }}
-
-      it 'prints a message to notify the user about the file creation' do
-        expect(subject).to have_received(:puts)
-        .with('== Creating changelogs/unreleased/20180119134323984_change.yml change file based on example ==')
-      end
-
-      it 'creates a file for the unreleased partial changes' do
-        expect(subject).to have_received(:system)
-        .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_change.yml')
-      end
+      let(:options) { { edit: true } }
 
       it 'opens the default text editor with the created file' do
         expect(subject).to have_received(:system)
-        .with('${VISUAL:-${EDITOR:-nano}} changelogs/unreleased/20180119134323984_change.yml')
+          .with('${VISUAL:-${EDITOR:-nano}} changelogs/unreleased/20180119134323984_change.yml')
       end
+    end
+
+    context 'with a name in a non snake case format' do
+      let(:name) { 'TestName' }
+
+      it 'converts the string to snake case notation, creating the file using it' do
+        expect(subject).to have_received(:system)
+          .with('cp changelogs/template.yml changelogs/unreleased/20180119134323984_test_name.yml')
+      end 
     end
   end
 
   describe '.run' do
     it 'creates an instance of the class to run the command' do
-      options = {}
-
-      expect_any_instance_of(described_class).to receive(:run).with(options)
-      described_class.run(options)
+      expect_any_instance_of(described_class).to receive(:run)
+      described_class.run('test_name', {})
     end
   end
 end


### PR DESCRIPTION
## Objective
Currently, all the change files generated by the `new` command will come with a name like `20180222130339054_change`.

What I propose in this PR is the ability to customize the change file name, like the rails' migrations.

If you use the command like this:
```
codelog new MyChangeFile
```
it will generate a file, with a name like `20180222130339054_my_change_file`

![aeee](https://user-images.githubusercontent.com/32220858/36826142-3e38db4e-1cea-11e8-8fd7-82035b74dd19.gif)

## Notes
I added subsections for the `Usage` section on the `README` file:
 *  `Creating a new change file`: Explain how to use the `new` command
*  `Releasing a version`: Explain how to use the `release` command

## How to test
1. Create a file without the name and verify if the file is created like the old way
2. Create a file with a custom name, using camel case or snake case and verify if the generated file name is correct

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[CONTRIBUTING]** document.
- [X] I have created a _Codelog changefile_ with the changes made to the branch.
- [X] I have created a test proving that my feature/fix does what it intends to do.
- [X] I have updated the documentation accordingly. (If needed)

[CONTRIBUTING]: https://github.com/codus/codelog/blob/master/CONTRIBUTING.md
