### PR TITLE
Fix interactive changefile creation

### DIFF
--- a/lib/codelog/clis/interactive.rb
+++ b/lib/codelog/clis/interactive.rb
@@ -39,7 +39,7 @@ module Codelog
 
           change = { change.chomp(':') => ask_for_changes([], level + 1) } if subcategory?(change)
 
-          ask_for_changes(changes.push(change))
+          ask_for_changes(changes.push(change), level)
         end
 
         def subcategory?(change)


### PR DESCRIPTION
## Objective
Every time a level was increased, it was printing only one `>` after the first change. Now it prints the correct number of `>`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[CONTRIBUTING]** document.

[CONTRIBUTING]: https://github.com/codus/codelog/blob/master/CONTRIBUTING.md
