### PR TITLE
Add version command

### DIFF
--- a/changelogs/unreleased/20190423215459480_change.yml
+++ b/changelogs/unreleased/20190423215459480_change.yml
@@ -1,0 +1,2 @@
+"Added":
+  - "Added `[-v | --version]` option to the `codelog` command"

--- a/lib/codelog/cli.rb
+++ b/lib/codelog/cli.rb
@@ -4,10 +4,10 @@ require 'yaml'
 
 module Codelog
   class CLI < Thor
-    map ['--version', '-v'] => :__print_version
+    map ['--version', '-v'] => :print_codelog_version
 
-    desc '[--version, -v]', 'prints current codelog version'
-    def __print_version
+    desc '[--version, -v]', 'prints current version of the codelog gem'
+    def print_codelog_version
       puts "Codelog version #{Codelog::VERSION}"
     end
 

--- a/lib/codelog/cli.rb
+++ b/lib/codelog/cli.rb
@@ -4,6 +4,13 @@ require 'yaml'
 
 module Codelog
   class CLI < Thor
+    map ['--version', '-v'] => :__print_version
+
+    desc '[--version, -v]', 'prints current codelog version'
+    def __print_version
+      puts "Codelog version #{Codelog::VERSION}"
+    end
+
     desc 'setup', 'Generate the changelogs folder structure and the template.yml file'
     def setup
       Codelog::Command::Setup.run


### PR DESCRIPTION
## Objective
Add `[-v | --version]` option to `codelog` command

## How to test
1. Run `codelog -v` or `codelog --version`
2. Verify that the correct codelog version is printed

## Checklist
- [X] I have read the **[CONTRIBUTING]** document.
- [x] I have created a _Codelog changefile_ with the changes made to the branch.
- [ ] I have created a test proving that my feature/fix does what it intends to do.
- [ ] I have updated the documentation accordingly. (If needed)

[CONTRIBUTING]: https://github.com/codus/codelog/blob/master/CONTRIBUTING.md
