### PR TITLE
Update runtime dependency thor to newer version

### DIFF
--- a/changelogs/unreleased/20210122141855785_change.yml
+++ b/changelogs/unreleased/20210122141855785_change.yml
@@ -1,0 +1,2 @@
+"Changed":
+  - Change thor runtime dependency to ~> 1.0

--- a/codelog.gemspec
+++ b/codelog.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.post_install_message = 'To start using the codelog run `codelog setup` and fill the `template.yml` file'
   spec.required_ruby_version = ">= 2.1.10"
 
-  spec.add_runtime_dependency "thor", "~> 0.19"
+  spec.add_runtime_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
## Objective
Update to a newer version of thor. Some common gems like react-rails and jquery-rails default to a newer version (1.0.1 at time of writing). This can lead to a dependency compatibility conflict.

## Notes
I decided to go with thor ~> 1.0 instead of ~> 1.1 because 1.1 was released just 2 days ago and I haven't had a chance to use it in production yet to confidently make that adjustment.

## How to test
```
bundle install
bundle exec rspec spec
```

## Breaking changes
None that I noticed

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **[CONTRIBUTING]** document.
- [x] I have created a _Codelog changefile_ with the changes made to the branch.
- [x] I have created a test proving that my feature/fix does what it intends to do.
- [x] I have updated the documentation accordingly. (If needed)

[CONTRIBUTING]: https://github.com/codus/codelog/blob/master/CONTRIBUTING.md
