### PR TITLE
Add automated testing via GitHub actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Test
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: 
+          - "2.5"
+          - "2.6"
+          - "2.7"
+          - "3.0"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1.62.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec spec

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # rspec failure tracking
 .rspec_status
+.actrc

--- a/changelogs/unreleased/20210504095206366_change.yml
+++ b/changelogs/unreleased/20210504095206366_change.yml
@@ -1,0 +1,2 @@
+"Added":
+  - GitHub action workflows for automatic testing

--- a/codelog.gemspec
+++ b/codelog.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "thor", "~> 1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rubocop", "~> 0.52.1"


### PR DESCRIPTION
## Objective
Automatically run rspec tests on multiple ruby versions on pull requests and code pushes.

## Notes
I did update the bundler dev dependency to 2.2, if this is undesirable I can downgrade the bundler that GitHub uses by default.

## How to test
You can run these tests locally using https://github.com/nektos/act and running `act -j test`. You'll want to add `ImageOS=ubuntu18` to your `.env` file and create a file named `.actrc` with the contents `-P ubuntu-latest=nektos/act-environments-ubuntu:18.04`. (Note running this the first time will require a large download, you can substitute the `ubuntu-latest` value with `catthehacker/ubuntu:act-18.04` for a medium-size image and `node:12.20.1-buster-slim` for a small image, although you'd need to add additional dependencies to the workflow

## Breaking changes
N/A

## Checklist
- [x] I have read the **[CONTRIBUTING]** document.
- [x] I have created a _Codelog changefile_ with the changes made to the branch.
- [x] I have created a test proving that my feature/fix does what it intends to do.
- [x] I have updated the documentation accordingly. (If needed)

[CONTRIBUTING]: https://github.com/codus/codelog/blob/master/CONTRIBUTING.md
